### PR TITLE
Update tests to use copier instead of cookiecutter

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -62,7 +62,7 @@ copyright_holder:
   default: Netherlands eScience Center
 code_of_conduct_email:
   type: str
-  default: {{ email }}
+  default: "{{ email }}"
 
 _subdirectory: template
 

--- a/copier.yml
+++ b/copier.yml
@@ -1,13 +1,5 @@
 # Essential questions
 
-directory_name:
-  type: str
-  default: my-python-project
-  help: Enter the name of the directory where the project will be created.
-  validator: >-
-        {% if not (directory_name | regex_search('^[a-z0-9\-]+$')) %}
-        directory_name must be lowercase, and can only contain letters, digits, and hyphens.
-        {% endif %}
 package_name:
   type: str
   default: my_python_package

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ include_package_data = True
 python_requires = >=3.8
 packages =
 install_requires =
-    cookiecutter==1.7.2
+    copier==9.2.0
 
 [options.data_files]
 # This section requires setuptools>=40.6.0
@@ -45,7 +45,8 @@ install_requires =
 dev =
     coverage [toml]
     pytest
-    pytest-cookies
+    pytest-copie
+    pyprojroot
 
 
 [tool:pytest]

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -4,18 +4,19 @@ import sys
 from sys import platform
 from typing import Sequence
 
+from pyprojroot.here import here
+from copier import run_copy
 import pytest
 
 IS_WINDOWS = platform.startswith('win')
 
 
-def test_project_folder(cookies):
-    project = cookies.bake()
+def test_project_folder(copie):
+    project = copie.copy()
 
     assert project.exit_code == 0
     assert project.exception is None
-    assert project.project_path.name == 'my-python-project'
-    assert project.project_path.is_dir()
+    assert project.project_dir.is_dir()
 
 
 def run(args: Sequence[str], dirpath: os.PathLike) -> subprocess.CompletedProcess:

--- a/tests/test_values.py
+++ b/tests/test_values.py
@@ -1,36 +1,36 @@
-def test_double_quotes_in_name_and_description(cookies):
+def test_double_quotes_in_name_and_description(copie):
     ctx = {
         "project_short_description": '"double quotes"',
         "full_name": '"name"name'
     }
-    project = cookies.bake(extra_context=ctx)
+    project = copie.copy(extra_answers=ctx)
 
     assert project.exit_code == 0
 
 
-def test_single_quotes_in_name_and_description(cookies):
+def test_single_quotes_in_name_and_description(copie):
     ctx = {
         "project_short_description": "'single quotes'",
         "full_name": "Mr. O'Keefe"
     }
-    project = cookies.bake(extra_context=ctx)
+    project = copie.copy(extra_answers=ctx)
 
     assert project.exit_code == 0
 
 
-def test_dash_in_directory_name(cookies):
+def test_dash_in_directory_name(copie):
     ctx = {
         "directory_name": "my-python-project"
     }
-    project = cookies.bake(extra_context=ctx)
+    project = copie.copy(extra_answers=ctx)
 
     assert project.exit_code == 0
 
 
-def test_space_in_directory_name(cookies):
+def test_space_in_directory_name(copie):
     ctx = {
         "directory_name": "my python project"
     }
-    project = cookies.bake(extra_context=ctx)
+    project = copie.copy(extra_answers=ctx)
 
     assert project.exit_code == 0


### PR DESCRIPTION
**Summary**

Updates all tests to remove references to `cookiecutter` or the `pytest-cookies` plugin, and makes sure all tests work with `copier` instead. Note that the tests in `test_values` only tests for not erroring, and the 'directory name with spaces' test now expects an error since that validation is not (yet) implemented for copier.

Fixes #1 (?)

**Instructions to review the pull request**

Add my fork as a remote and switch to the `1-update-tests` branch (or make a new clone, your choice), then install the required dependencies and run the tests.

**Note:** On my local WSL installation, the `tox` test hangs for some reason, although I suspect this may be a pyenv related issue. I'm assuming/hoping that this will not be a problem in the CI.

```
git remote add sjvrijn git@github.com:sjvrijn/copier-python-template.git
git fetch sjvrijn
git switch 1-update-tests
python -m venv venv
source venv/bin/activate
python -m pip install --upgrade pip setuptools
pip install ".[dev]"
pytest
```

